### PR TITLE
도메인간 쿠키 공유 설정

### DIFF
--- a/src/main/java/shop/dalda/security/jwt/TokenProvider.java
+++ b/src/main/java/shop/dalda/security/jwt/TokenProvider.java
@@ -71,6 +71,7 @@ public class TokenProvider {
                 .httpOnly(true)
                 .secure(true)
                 .sameSite("Lax")
+                .domain(".dalda.shop")
                 .maxAge(TOKEN_EXPIRATION / 1000)
                 .path("/")
                 .build();
@@ -80,6 +81,7 @@ public class TokenProvider {
                 .httpOnly(true)
                 .secure(true)
                 .sameSite("Lax")
+                .domain(".dalda.shop")
                 .maxAge((TOKEN_EXPIRATION * 48) / 1000)
                 .path("/")
                 .build();


### PR DESCRIPTION
기존에는 쿠키에 도메인값을 명시하지 않아, null값이 들어있었습니다.
아마 그래서 동일 도메인끼리만 공유가 가능하도록 설정된 것 같습니다.

쿠키를 생성할 때, 도메인 정보를 명시하여 도메인간 공유가 가능하도록 변경하였습니다.