### PR TITLE
[DD-98] redirect uri 파싱 오류

### DIFF
--- a/src/main/java/shop/dalda/security/auth/LogoutSuccessHandler.java
+++ b/src/main/java/shop/dalda/security/auth/LogoutSuccessHandler.java
@@ -23,8 +23,8 @@ import java.util.Optional;
 public class LogoutSuccessHandler extends SimpleUrlLogoutSuccessHandler {
     private final RedisService redisService;
     private final TokenProvider tokenProvider;
-    @Value("${app.oauth2.redirectUri}")
-    private String REDIRECT_URI;
+    @Value("${app.oauth2.defaultUri}")
+    private String DEFAULT_URI;
 
     @Override
     public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
@@ -42,6 +42,6 @@ public class LogoutSuccessHandler extends SimpleUrlLogoutSuccessHandler {
         }
 
         CookieUtil.deleteCookie(request, response, "refreshToken");
-        getRedirectStrategy().sendRedirect(request, response, REDIRECT_URI);
+        getRedirectStrategy().sendRedirect(request, response, DEFAULT_URI);
     }
 }

--- a/src/main/java/shop/dalda/security/jwt/TokenProvider.java
+++ b/src/main/java/shop/dalda/security/jwt/TokenProvider.java
@@ -34,8 +34,8 @@ public class TokenProvider {
     @Value("${app.auth.tokenSecret}")
     private String TOKEN_SECRET;
 
-    @Value("${app.oauth2.host}")
-    private String HOST;
+    @Value("${app.oauth2.domain}")
+    private String DOMAIN;
 
     public void createTokens(Authentication authentication, HttpServletResponse response) {
         CustomOAuth2User user = (CustomOAuth2User) authentication.getPrincipal();
@@ -74,7 +74,7 @@ public class TokenProvider {
                 .httpOnly(true)
                 .secure(true)
                 .sameSite("Lax")
-                .domain(HOST)
+                .domain(DOMAIN)
                 .maxAge(TOKEN_EXPIRATION / 1000)
                 .path("/")
                 .build();
@@ -85,7 +85,7 @@ public class TokenProvider {
                 .httpOnly(true)
                 .secure(true)
                 .sameSite("Lax")
-                .domain(HOST)
+                .domain(DOMAIN)
                 .maxAge((TOKEN_EXPIRATION * 48) / 1000)
                 .path("/")
                 .build();

--- a/src/test/java/shop/dalda/utils/WithMockCustomOAuth2User.java
+++ b/src/test/java/shop/dalda/utils/WithMockCustomOAuth2User.java
@@ -10,5 +10,5 @@ import java.lang.annotation.RetentionPolicy;
 public @interface WithMockCustomOAuth2User {
     long id() default 1L;
     String password() default "";
-    String authority() default "GUEST";
+    String authority() default "MEMBER";
 }


### PR DESCRIPTION
간혹 uri 첫 인덱스에 공백이 포함되는 경우가 있다고 하여 공백 제거를 위한 함수호출 추가했고,
쿠키 도메인 설정시 변수명 수정했습니다.