### PR TITLE
[DD-100] TomcatConfig 추가

### DIFF
--- a/src/main/java/shop/dalda/config/TomcatConfig.java
+++ b/src/main/java/shop/dalda/config/TomcatConfig.java
@@ -1,0 +1,15 @@
+package shop.dalda.config;
+
+import org.apache.tomcat.util.http.LegacyCookieProcessor;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TomcatConfig implements WebServerFactoryCustomizer<TomcatServletWebServerFactory>{
+
+    @Override
+    public void customize(TomcatServletWebServerFactory factory) {
+        factory.addContextCustomizers(context -> context.setCookieProcessor(new LegacyCookieProcessor()));
+    }
+}


### PR DESCRIPTION
톰캣 8.5 이상의 버전에서 쿠키 도메인 앞에 .을 붙일 경우 에러가 발생하여 config 클래스 추가했습니다.